### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ There might be issues here and there, like the category, the individual ones, bu
 
 You can have a graphical preview here (use mouse to move / zoom): 
 
-https://rawgit.com/unruledboy/DevelopmentStack/master/ux/DevelopmentStack.htm 
+https://combinatronics.com/unruledboy/DevelopmentStack/master/ux/DevelopmentStack.htm 
 
 
 # The Development Stack


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.